### PR TITLE
[fix] Transactional Outbox 패턴 적용해서 알림 로직 수정

### DIFF
--- a/src/main/java/com/todaysound/todaysound_server/domain/alarm/controller/InternalAlertController.java
+++ b/src/main/java/com/todaysound/todaysound_server/domain/alarm/controller/InternalAlertController.java
@@ -1,19 +1,20 @@
 package com.todaysound.todaysound_server.domain.alarm.controller;
 
+import static com.todaysound.todaysound_server.global.utils.LogMarkers.BUSINESS;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.todaysound.todaysound_server.domain.alarm.entity.NotificationOutbox;
+import com.todaysound.todaysound_server.domain.alarm.repository.NotificationOutboxRepository;
 import com.todaysound.todaysound_server.domain.subscription.entity.Subscription;
 import com.todaysound.todaysound_server.domain.subscription.repository.SubscriptionRepository;
 import com.todaysound.todaysound_server.domain.summary.entity.Summary;
 import com.todaysound.todaysound_server.domain.summary.repository.SummaryRepository;
-import com.todaysound.todaysound_server.domain.user.entity.User;
-import static com.todaysound.todaysound_server.global.utils.LogMarkers.BUSINESS;
-import static net.logstash.logback.argument.StructuredArguments.kv;
-
-import com.todaysound.todaysound_server.global.application.FCMService;
 import com.todaysound.todaysound_server.global.exception.BaseException;
 import com.todaysound.todaysound_server.global.exception.CommonErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,9 +22,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 크롤러용 알림 생성 엔드포인트
- * <p>
- * POST /internal/alerts { "user_id": 10, "subscription_id": 1, "site_post_id": "12345", "title": "게시글 제목", "url":
- * "https://...", "content_raw": "...원문...", "content_summary": "...요약...", "keyword_matched": true }
+ *
+ * [Transactional Outbox 패턴 적용]
+ * - 기존: FCM 전송 → DB 저장 (순서 역전 + 원자성 없음)
+ * - 개선: DB 저장(Summary + NotificationOutbox)을 단일 트랜잭션으로 묶은 후,
+ *         NotificationOutboxScheduler 가 주기적으로 outbox 를 읽어 FCM 전송을 담당한다.
+ * - 보장: FCM 과 DB 저장 중 하나만 성공하는 중간 상태가 발생하지 않는다.
  */
 @Slf4j
 @RestController
@@ -33,9 +37,10 @@ public class InternalAlertController implements InternalAlertApi {
 
     private final SubscriptionRepository subscriptionRepository;
     private final SummaryRepository summaryRepository;
-    private final FCMService fcmService;
+    private final NotificationOutboxRepository outboxRepository;
 
     @PostMapping("/alerts")
+    @Transactional
     public void createAlert(@RequestBody InternalAlertRequest request) {
         log.info(BUSINESS, "크롤러 알림 수신 {} {} {}",
                 kv("userId", request.userId()),
@@ -45,40 +50,36 @@ public class InternalAlertController implements InternalAlertApi {
         Subscription subscription = subscriptionRepository.findById(request.subscriptionId())
                 .orElseThrow(() -> BaseException.type(CommonErrorCode.ENTITY_NOT_FOUND));
 
-        // 간단한 소유자 검증 (userId 가 다르면 거부)
         if (!subscription.getUser().getId().equals(request.userId())) {
             throw BaseException.type(CommonErrorCode.FORBIDDEN);
         }
 
-        // 알림이 활성화된 구독에 대해서만 푸시 전송
-        if (subscription.isAlarmEnabled()) {
-            User user = subscription.getUser();
-            String prefix = "[" + request.siteAlias + "]";
-
-            fcmService.sendNotificationToUser(
-                    user,
-                    prefix + request.title(),
-                    request.contentSummary()
-            );
-        }
-
-        // sitePostId 를 해시 키로 사용
+        // ① Summary 저장 (트랜잭션 안)
         Summary summary = Summary.create(
                 request.sitePostId(),
                 request.title(),
                 request.contentSummary(),
                 request.url(),
                 request.publishedAt(),
-                request.keywordMatched,
+                request.keywordMatched(),
                 subscription
         );
-
         summaryRepository.save(summary);
+
+        // ② 알림이 활성화된 경우 outbox 에 기록 (같은 트랜잭션)
+        // FCM 을 직접 호출하지 않고 "전송할 것"을 DB 에 기록한다.
+        // Summary 저장과 outbox 저장이 하나의 트랜잭션이므로 둘 다 커밋되거나 둘 다 롤백된다.
+        if (subscription.isAlarmEnabled()) {
+            String title = "[" + request.siteAlias() + "] " + request.title();
+            NotificationOutbox outbox = NotificationOutbox.create(
+                    subscription.getUser().getId(), title, request.contentSummary());
+            outboxRepository.save(outbox);
+        }
 
         log.info(BUSINESS, "크롤러 알림 처리 완료 {} {} {}",
                 kv("subscriptionId", request.subscriptionId()),
                 kv("sitePostId", request.sitePostId()),
-                kv("alarmSent", subscription.isAlarmEnabled()));
+                kv("alarmQueued", subscription.isAlarmEnabled()));
     }
 
     public record InternalAlertRequest(
@@ -95,5 +96,3 @@ public class InternalAlertController implements InternalAlertApi {
     ) {
     }
 }
-
-

--- a/src/main/java/com/todaysound/todaysound_server/domain/alarm/entity/NotificationOutbox.java
+++ b/src/main/java/com/todaysound/todaysound_server/domain/alarm/entity/NotificationOutbox.java
@@ -1,0 +1,70 @@
+package com.todaysound.todaysound_server.domain.alarm.entity;
+
+import com.todaysound.todaysound_server.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Transactional Outbox 패턴 구현체
+ *
+ * FCM 알림을 직접 전송하는 대신 이 테이블에 "전송할 것"을 기록한다.
+ * Summary 저장과 같은 트랜잭션 내에서 저장되므로 둘 다 커밋되거나 둘 다 롤백된다.
+ * NotificationOutboxScheduler 가 주기적으로 PENDING 건을 읽어 FCM 전송을 수행한다.
+ */
+@Entity
+@Getter
+@Table(name = "notification_outbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationOutbox extends BaseEntity {
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OutboxStatus status;
+
+    @Column(nullable = false)
+    private int retryCount;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public static NotificationOutbox create(Long userId, String title, String body) {
+        NotificationOutbox outbox = new NotificationOutbox();
+        outbox.userId = userId;
+        outbox.title = title;
+        outbox.body = body;
+        outbox.status = OutboxStatus.PENDING;
+        outbox.retryCount = 0;
+        outbox.createdAt = LocalDateTime.now();
+        return outbox;
+    }
+
+    public void markAsSent() {
+        this.status = OutboxStatus.SENT;
+    }
+
+    /**
+     * 재시도 횟수를 증가시키고, maxRetry 초과 시 FAILED 로 전환한다.
+     */
+    public void incrementRetry(int maxRetry) {
+        this.retryCount++;
+        if (this.retryCount >= maxRetry) {
+            this.status = OutboxStatus.FAILED;
+        }
+    }
+}

--- a/src/main/java/com/todaysound/todaysound_server/domain/alarm/entity/NotificationOutbox.java
+++ b/src/main/java/com/todaysound/todaysound_server/domain/alarm/entity/NotificationOutbox.java
@@ -59,6 +59,13 @@ public class NotificationOutbox extends BaseEntity {
     }
 
     /**
+     * 탈퇴 사용자 등 재시도 없이 즉시 실패 처리할 때 사용한다.
+     */
+    public void markAsFailed() {
+        this.status = OutboxStatus.FAILED;
+    }
+
+    /**
      * 재시도 횟수를 증가시키고, maxRetry 초과 시 FAILED 로 전환한다.
      */
     public void incrementRetry(int maxRetry) {

--- a/src/main/java/com/todaysound/todaysound_server/domain/alarm/entity/OutboxStatus.java
+++ b/src/main/java/com/todaysound/todaysound_server/domain/alarm/entity/OutboxStatus.java
@@ -1,0 +1,7 @@
+package com.todaysound.todaysound_server.domain.alarm.entity;
+
+public enum OutboxStatus {
+    PENDING,  // 전송 대기
+    SENT,     // 전송 완료
+    FAILED    // 최대 재시도 횟수 초과
+}

--- a/src/main/java/com/todaysound/todaysound_server/domain/alarm/repository/NotificationOutboxRepository.java
+++ b/src/main/java/com/todaysound/todaysound_server/domain/alarm/repository/NotificationOutboxRepository.java
@@ -1,0 +1,11 @@
+package com.todaysound.todaysound_server.domain.alarm.repository;
+
+import com.todaysound.todaysound_server.domain.alarm.entity.NotificationOutbox;
+import com.todaysound.todaysound_server.domain.alarm.entity.OutboxStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationOutboxRepository extends JpaRepository<NotificationOutbox, Long> {
+
+    List<NotificationOutbox> findByStatusOrderByCreatedAtAsc(OutboxStatus status);
+}

--- a/src/main/java/com/todaysound/todaysound_server/domain/alarm/scheduler/NotificationOutboxScheduler.java
+++ b/src/main/java/com/todaysound/todaysound_server/domain/alarm/scheduler/NotificationOutboxScheduler.java
@@ -1,0 +1,95 @@
+package com.todaysound.todaysound_server.domain.alarm.scheduler;
+
+import static com.todaysound.todaysound_server.global.utils.LogMarkers.BUSINESS;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import com.todaysound.todaysound_server.domain.alarm.entity.NotificationOutbox;
+import com.todaysound.todaysound_server.domain.alarm.entity.OutboxStatus;
+import com.todaysound.todaysound_server.domain.alarm.repository.NotificationOutboxRepository;
+import com.todaysound.todaysound_server.domain.user.entity.User;
+import com.todaysound.todaysound_server.domain.user.repository.UserRepository;
+import com.todaysound.todaysound_server.global.application.FCMService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Transactional Outbox 패턴의 소비자(Consumer) 역할.
+ *
+ * notification_outbox 테이블에서 PENDING 상태인 항목을 주기적으로 읽어 FCM 전송을 수행한다.
+ * FCM 전송에 실패하면 retryCount 를 증가시키며, MAX_RETRY 초과 시 FAILED 로 전환한다.
+ *
+ * [처리 흐름]
+ * PENDING → (전송 성공) → SENT
+ * PENDING → (전송 실패 × MAX_RETRY) → FAILED
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationOutboxScheduler {
+
+    private static final int MAX_RETRY = 3;
+
+    private final NotificationOutboxRepository outboxRepository;
+    private final FCMService fcmService;
+    private final UserRepository userRepository;
+
+    /**
+     * 5초마다 PENDING 상태인 outbox 항목을 처리한다.
+     *
+     * FCMService.sendNotificationToUser() 는 내부적으로 FirebaseMessagingException 을 catch 하므로
+     * Firebase 장애 시에도 예외가 전파되지 않는다. 단, DB 접근 실패 등 인프라 레벨 오류는
+     * 트랜잭션 전체를 롤백시켜 다음 주기에 재처리된다.
+     */
+    @Scheduled(fixedDelay = 5000)
+    @Transactional
+    public void processOutbox() {
+        List<NotificationOutbox> pending =
+                outboxRepository.findByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);
+
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        log.info(BUSINESS, "Outbox 처리 시작 {}", kv("pendingCount", pending.size()));
+
+        for (NotificationOutbox outbox : pending) {
+            try {
+                User user = userRepository.findById(outbox.getUserId()).orElse(null);
+
+                if (user == null) {
+                    // 탈퇴한 사용자: 재시도 없이 즉시 FAILED 처리
+                    log.warn(BUSINESS, "Outbox 전송 대상 사용자 없음 (탈퇴) {} {}",
+                            kv("outboxId", outbox.getId()),
+                            kv("userId", outbox.getUserId()));
+                    outbox.incrementRetry(1);
+                    continue;
+                }
+
+                fcmService.sendNotificationToUser(user, outbox.getTitle(), outbox.getBody());
+                outbox.markAsSent();
+
+                log.info(BUSINESS, "Outbox FCM 전송 성공 {} {}",
+                        kv("outboxId", outbox.getId()),
+                        kv("userId", outbox.getUserId()));
+
+            } catch (Exception e) {
+                log.warn(BUSINESS, "Outbox FCM 전송 실패 {} {} {}",
+                        kv("outboxId", outbox.getId()),
+                        kv("retryCount", outbox.getRetryCount()),
+                        kv("error", e.getMessage()));
+
+                outbox.incrementRetry(MAX_RETRY);
+
+                if (outbox.getStatus() == OutboxStatus.FAILED) {
+                    log.error(BUSINESS, "Outbox 최대 재시도 초과, FAILED 처리 {} {}",
+                            kv("outboxId", outbox.getId()),
+                            kv("userId", outbox.getUserId()));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/todaysound/todaysound_server/domain/alarm/scheduler/NotificationOutboxScheduler.java
+++ b/src/main/java/com/todaysound/todaysound_server/domain/alarm/scheduler/NotificationOutboxScheduler.java
@@ -6,21 +6,23 @@ import static net.logstash.logback.argument.StructuredArguments.kv;
 import com.todaysound.todaysound_server.domain.alarm.entity.NotificationOutbox;
 import com.todaysound.todaysound_server.domain.alarm.entity.OutboxStatus;
 import com.todaysound.todaysound_server.domain.alarm.repository.NotificationOutboxRepository;
+import com.todaysound.todaysound_server.domain.alarm.service.NotificationOutboxProcessor;
 import com.todaysound.todaysound_server.domain.user.entity.User;
 import com.todaysound.todaysound_server.domain.user.repository.UserRepository;
-import com.todaysound.todaysound_server.global.application.FCMService;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Transactional Outbox 패턴의 소비자(Consumer) 역할.
  *
- * notification_outbox 테이블에서 PENDING 상태인 항목을 주기적으로 읽어 FCM 전송을 수행한다.
- * FCM 전송에 실패하면 retryCount 를 증가시키며, MAX_RETRY 초과 시 FAILED 로 전환한다.
+ * notification_outbox 테이블에서 PENDING 상태인 항목을 주기적으로 읽어
+ * NotificationOutboxProcessor 에 위임하여 FCM 전송을 수행한다.
  *
  * [처리 흐름]
  * PENDING → (전송 성공) → SENT
@@ -31,21 +33,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class NotificationOutboxScheduler {
 
-    private static final int MAX_RETRY = 3;
-
     private final NotificationOutboxRepository outboxRepository;
-    private final FCMService fcmService;
     private final UserRepository userRepository;
+    private final NotificationOutboxProcessor outboxProcessor;
 
     /**
      * 5초마다 PENDING 상태인 outbox 항목을 처리한다.
-     *
-     * FCMService.sendNotificationToUser() 는 내부적으로 FirebaseMessagingException 을 catch 하므로
-     * Firebase 장애 시에도 예외가 전파되지 않는다. 단, DB 접근 실패 등 인프라 레벨 오류는
-     * 트랜잭션 전체를 롤백시켜 다음 주기에 재처리된다.
      */
     @Scheduled(fixedDelay = 5000)
-    @Transactional
     public void processOutbox() {
         List<NotificationOutbox> pending =
                 outboxRepository.findByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);
@@ -56,40 +51,18 @@ public class NotificationOutboxScheduler {
 
         log.info(BUSINESS, "Outbox 처리 시작 {}", kv("pendingCount", pending.size()));
 
+        // N+1 방지: 필요한 User를 한 번의 쿼리로 일괄 조회
+        Set<Long> userIds = pending.stream()
+                .map(NotificationOutbox::getUserId)
+                .collect(Collectors.toSet());
+
+        Map<Long, User> userMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, user -> user));
+
+        // 아이템별로 별도 트랜잭션을 열어 처리 (Processor 에 위임)
+        // 한 아이템의 실패가 다른 아이템에 영향을 주지 않는다
         for (NotificationOutbox outbox : pending) {
-            try {
-                User user = userRepository.findById(outbox.getUserId()).orElse(null);
-
-                if (user == null) {
-                    // 탈퇴한 사용자: 재시도 없이 즉시 FAILED 처리
-                    log.warn(BUSINESS, "Outbox 전송 대상 사용자 없음 (탈퇴) {} {}",
-                            kv("outboxId", outbox.getId()),
-                            kv("userId", outbox.getUserId()));
-                    outbox.incrementRetry(1);
-                    continue;
-                }
-
-                fcmService.sendNotificationToUser(user, outbox.getTitle(), outbox.getBody());
-                outbox.markAsSent();
-
-                log.info(BUSINESS, "Outbox FCM 전송 성공 {} {}",
-                        kv("outboxId", outbox.getId()),
-                        kv("userId", outbox.getUserId()));
-
-            } catch (Exception e) {
-                log.warn(BUSINESS, "Outbox FCM 전송 실패 {} {} {}",
-                        kv("outboxId", outbox.getId()),
-                        kv("retryCount", outbox.getRetryCount()),
-                        kv("error", e.getMessage()));
-
-                outbox.incrementRetry(MAX_RETRY);
-
-                if (outbox.getStatus() == OutboxStatus.FAILED) {
-                    log.error(BUSINESS, "Outbox 최대 재시도 초과, FAILED 처리 {} {}",
-                            kv("outboxId", outbox.getId()),
-                            kv("userId", outbox.getUserId()));
-                }
-            }
+            outboxProcessor.process(outbox.getId(), userMap.get(outbox.getUserId()));
         }
     }
 }

--- a/src/main/java/com/todaysound/todaysound_server/domain/alarm/service/NotificationOutboxProcessor.java
+++ b/src/main/java/com/todaysound/todaysound_server/domain/alarm/service/NotificationOutboxProcessor.java
@@ -1,0 +1,73 @@
+package com.todaysound.todaysound_server.domain.alarm.service;
+
+import static com.todaysound.todaysound_server.global.utils.LogMarkers.BUSINESS;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+import com.todaysound.todaysound_server.domain.alarm.entity.NotificationOutbox;
+import com.todaysound.todaysound_server.domain.alarm.entity.OutboxStatus;
+import com.todaysound.todaysound_server.domain.alarm.repository.NotificationOutboxRepository;
+import com.todaysound.todaysound_server.domain.user.entity.User;
+import com.todaysound.todaysound_server.global.application.FCMService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Outbox 항목 하나를 처리하는 단위 컴포넌트.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationOutboxProcessor {
+
+    private static final int MAX_RETRY = 3;
+
+    private final NotificationOutboxRepository outboxRepository;
+    private final FCMService fcmService;
+
+    /**
+     * outbox 항목 하나를 처리한다. 스케줄러가 아이템별로 호출한다.
+     *
+     * @param outboxId 처리할 outbox의 PK
+     * @param user     스케줄러에서 batch 조회한 User (탈퇴 사용자인 경우 null)
+     */
+    @Transactional
+    public void process(Long outboxId, User user) {
+        // detached 상태의 엔티티를 다시 로드해 managed 상태로 전환
+        NotificationOutbox outbox = outboxRepository.findById(outboxId)
+                .orElseThrow(() -> new IllegalStateException("Outbox not found: " + outboxId));
+
+        // 탈퇴한 사용자: 재시도 없이 즉시 FAILED
+        if (user == null) {
+            log.warn(BUSINESS, "Outbox 전송 대상 사용자 없음 (탈퇴) {} {}",
+                    kv("outboxId", outboxId),
+                    kv("userId", outbox.getUserId()));
+            outbox.markAsFailed();
+            return;
+        }
+
+        try {
+            fcmService.sendNotificationToUser(user, outbox.getTitle(), outbox.getBody());
+            outbox.markAsSent();
+
+            log.info(BUSINESS, "Outbox FCM 전송 성공 {} {}",
+                    kv("outboxId", outboxId),
+                    kv("userId", outbox.getUserId()));
+
+        } catch (Exception e) {
+            log.warn(BUSINESS, "Outbox FCM 전송 실패 {} {} {}",
+                    kv("outboxId", outboxId),
+                    kv("retryCount", outbox.getRetryCount()),
+                    kv("error", e.getMessage()));
+
+            outbox.incrementRetry(MAX_RETRY);
+
+            if (outbox.getStatus() == OutboxStatus.FAILED) {
+                log.error(BUSINESS, "Outbox 최대 재시도 초과, FAILED 처리 {} {}",
+                        kv("outboxId", outboxId),
+                        kv("userId", outbox.getUserId()));
+            }
+        }
+    }
+}

--- a/src/main/resources/db/migration/V5__create_notification_outbox.sql
+++ b/src/main/resources/db/migration/V5__create_notification_outbox.sql
@@ -1,0 +1,16 @@
+-- notification_outbox: Transactional Outbox 테이블 생성
+CREATE TABLE notification_outbox
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id     BIGINT        NOT NULL,
+    title       VARCHAR(255)  NOT NULL,
+    body        TEXT          NOT NULL,
+    status      VARCHAR(20)   NOT NULL,
+    retry_count INT           NOT NULL,
+    created_at  DATETIME(6)   NOT NULL
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+-- 조회 최적화를 위한 인덱스 (PENDING + created_at 순)
+CREATE INDEX idx_notification_outbox_status_created_at
+    ON notification_outbox (status, created_at);

--- a/src/test/java/com/todaysound/todaysound_server/support/isolation/TableNameExtractorImpl.java
+++ b/src/test/java/com/todaysound/todaysound_server/support/isolation/TableNameExtractorImpl.java
@@ -1,0 +1,22 @@
+package com.todaysound.todaysound_server.support.isolation;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+class TableNameExtractorImpl implements TableNameExtractor {
+
+    @Override
+    public List<String> getNames() {
+        return List.of(
+                "keywords",
+                "urls",
+                "users",
+                "fcm_tokens",
+                "subscriptions",
+                "subscriptions_keywords",
+                "summaries",
+                "notification_outbox"
+        );
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

[//]: #84 
어떤 변경사항이 있었나요?

- [X] 🐛 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, Swagger, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related

[//]: # (작업 내용 간단 소개)

<html><head></head><body><h1>Transactional Outbox 패턴</h1>
<p>TodaySound 서비스는 "피드에 새 글이 올라오면 사용자 폰에 알림을 보내주는 것"이 핵심 기능임. 그런데 운영하다 보니 <strong>같은 피드를 구독한 사용자인데 어떤 사람은 알림이 오고 어떤 사람은 안 오는 현상</strong>이 발생함.</p>
<hr>
<h2>왜 이런 일이 벌어졌는가</h2>
<p>기존 코드의 실행 순서가 이랬음</p>
<pre><code>① FCM 전송 (Firebase에 HTTP 요청) → 외부 시스템, 한번 보내면 취소 불가
② DB 저장 (summaryRepository.save())
</code></pre>
<p>그리고 <strong>@Transactional이 없었음</strong>. 즉 ①과 ②는 아무 관계 없는 독립된 두 작업임.</p>
<p>크롤러가 구독자 10명에 대해 이 API를 10번 호출하는데, 각 요청이 <strong>독립적으로 다른 지점에서 실패</strong>할 수 있음</p>
<ul>
<li>User A: ① 성공 ② 성공 → <strong>정상</strong> (알림 오고, 앱에도 있음)</li>
<li>User B: ① 실패 ② 실행 안 됨 → <strong>알림도 없고 앱에도 없음</strong> (서비스가 조용히 죽은 것)</li>
<li>User C: ① 성공 ② 실패 → <strong>알림은 왔는데 앱에 아무것도 없음</strong> (Phantom Notification)</li>
</ul>
<p>이게 뒤섞여서 "어떤 핸드폰은 오고 어떤 핸드폰은 안 온다"는 현상이 나온 것임.</p>
<hr>
<h2>해결 과정</h2>
<h3>시도 1: 순서만 바꾸기 → 불완전</h3>
<pre><code>① DB 저장 먼저
② FCM 나중에
</code></pre>
<p>@Transactional이 없으니 ①은 즉시 auto-commit됨. ②에서 FCM이 실패하면? → DB에는 데이터가 있는데 알림은 영영 안 감. <strong>재시도 수단이 없음.</strong></p>
<h3>시도 2: @Transactional + afterCommit() → 거의 해결, 하지만 한계</h3>
<pre><code>@Transactional 시작
  ① DB 저장 (아직 커밋 안 됨)
  ② afterCommit 콜백 등록
트랜잭션 커밋 → DB 영구 저장 확정
  ③ afterCommit() 실행 → FCM 전송
</code></pre>
<p>이러면 <strong>DB 커밋이 실패하면 FCM이 아예 실행 안 됨</strong> → Phantom 문제 해결됨.</p>
<p>하지만: afterCommit() 실행 중에 <strong>서버가 죽거나 Firebase가 일시 장애</strong>이면? → 그 알림은 영구 유실됨. afterCommit()은 메모리에만 있는 콜백이라 서버가 재시작되면 사라짐.</p>
<h3>시도 3: CDC (Debezium) → 검토했지만 부적합</h3>
<p>CDC는 DB의 binlog를 읽어서 변경을 감지하는 방식인데, 상황에 부적합함</p>
<ul>
<li>CDC가 캡처하는 건 Summary 테이블의 row 변경뿐인데, FCM 전송에는 <strong>User의 FCM 토큰, subscription의 siteAlias</strong> 등 다른 도메인 정보가 필요함 → CDC만으로는 알림을 구성할 수 없음</li>
<li>테이블 스키마가 바뀔 때마다 전송 로직도 영향을 받음</li>
<li>Debezium 같은 인프라를 추가로 운영해야 함</li>
</ul>
<hr>
<h2>최종 해결: Transactional Outbox 패턴</h2>
<p>핵심 아이디어:</p>
<blockquote>
<p><strong>FCM을 직접 쏘지 말고, "쏴야 할 것"을 DB에 기록. 비즈니스 데이터와 같은 트랜잭션에 넣으면 원자성이 보장된다. 실제 전송은 별도 스케줄러가 책임진다.</strong></p>
</blockquote>
<pre><code>@Transactional:
  ① summaryRepository.save()              ─┐ 하나의 트랜잭션
  ② outboxRepository.save(status=PENDING)  ─┘ 둘 다 커밋 or 둘 다 롤백
  (FCM 전송 코드 없음!)
<br>
별도 스케줄러 (5초마다):
  ③ PENDING인 건 조회
  ④ FCM 전송 시도
     → 성공: status = SENT
     → 실패: retryCount++, 3회 초과 시 FAILED
</code></pre>
<p>왜 이게 모든 문제를 해결하는지 케이스별로 보면:</p>

상황 | 기존 코드 | Outbox 적용 후
-- | -- | --
DB 저장 실패 | FCM은 이미 나감 (Phantom) | 트랜잭션 롤백 → outbox도 없음 → FCM 전송 자체가 안 일어남
FCM 전송 실패 | DB도 저장 안 됨, 유실 | DB에는 저장됨 + PENDING 유지 → 5초 후 재시도
서버 재시작 | afterCommit 콜백은 메모리에만 있어서 유실 | PENDING이 DB에 남아있음 → 재시작 후 자동 재처리
Firebase 일시 장애 | 영구 유실 | 장애 복구 후 PENDING 건 자동 재전송

<hr>
<h2>트레이드오프: 뭘 포기하고 뭘 얻었는가</h2>
<p><strong>포기한 것</strong>: 알림의 즉각성. 기존에는 요청 처리 중에 바로 FCM을 쐈는데, 이제는 스케줄러 주기(최대 5초) 만큼 지연이 생김.</p>
<p><strong>얻은 것</strong>: 알림의 신뢰성. 모든 사용자에게 <strong>eventually 반드시 전달된다</strong>는 보장.</p>
<p>이건 의도된 트레이드오프. TodaySound는 실시간 메신저가 아니라 피드 알림 서비스. 5초 늦게 오는 게 문제가 아니라, <strong>안 오는 게 문제</strong>임.</p>
<hr>

## To Reviewers 📢

<p></strong>"알림 전송과 데이터 저장의 원자성을 DB 트랜잭션으로 보장하고, 제어할 수 없는 외부 시스템(Firebase)의 일시적 장애에 대한 복구 책임을 애플리케이션 내부로 가져오기 위해서 수정함."</p>