### PR TITLE
feat(observability): export traces to Tempo via Zipkin reporter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     // Micrometer Tracing - traceId/spanId 자동 생성
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    // Tempo로 trace export (Zipkin wire format). brave가 classpath에 있으면
+    // Spring Boot이 ZipkinAutoConfiguration로 자동 구성.
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
     // 구조화된 JSON 로깅
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'

--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,12 @@ dependencies {
     // Micrometer Tracing - traceId/spanId 자동 생성
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     // Tempo로 trace export (Zipkin wire format).
-    // Spring Boot 3.4+ BOM이 io.zipkin.reporter3 그룹을 관리(reporter2는 deprecated).
+    // Spring Boot 3.5 BOM이 io.zipkin.reporter2 그룹을 3.5.x 버전으로 관리.
+    // ("reporter3" 그룹은 존재하지 않음 — 그룹명은 reporter2 유지하고 내부 버전만 v3로 올라옴.)
     // - reporter-brave: Brave Span → Zipkin V2 모델 변환
     // - sender-urlconnection: 실제 HTTP POST. Sender 없으면 ZipkinSpanHandler 빈 생성 안 됨
-    implementation 'io.zipkin.reporter3:zipkin-reporter-brave'
-    implementation 'io.zipkin.reporter3:zipkin-sender-urlconnection'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    implementation 'io.zipkin.reporter2:zipkin-sender-urlconnection'
 
     // 구조화된 JSON 로깅
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'

--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,12 @@ dependencies {
 
     // Micrometer Tracing - traceId/spanId 자동 생성
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
-    // Tempo로 trace export (Zipkin wire format). brave가 classpath에 있으면
-    // Spring Boot이 ZipkinAutoConfiguration로 자동 구성.
-    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    // Tempo로 trace export (Zipkin wire format).
+    // Spring Boot 3.4+ BOM이 io.zipkin.reporter3 그룹을 관리(reporter2는 deprecated).
+    // - reporter-brave: Brave Span → Zipkin V2 모델 변환
+    // - sender-urlconnection: 실제 HTTP POST. Sender 없으면 ZipkinSpanHandler 빈 생성 안 됨
+    implementation 'io.zipkin.reporter3:zipkin-reporter-brave'
+    implementation 'io.zipkin.reporter3:zipkin-sender-urlconnection'
 
     // 구조화된 JSON 로깅
     implementation 'net.logstash.logback:logstash-logback-encoder:8.0'

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -68,6 +68,12 @@ management:
   tracing:
     sampling:
       probability: 1.0
+    propagation:
+      type: b3,w3c        # Brave 기본은 b3. w3c도 받아서 OTel 클라이언트 호환
+  zipkin:
+    tracing:
+      # 같은 web 도커 네트워크의 Tempo. ZIPKIN_ENDPOINT 환경변수로 오버라이드 가능.
+      endpoint: ${ZIPKIN_ENDPOINT:http://tempo:9411/api/v2/spans}
 
 sentry:
   dsn: ${SENTRY_DSN}


### PR DESCRIPTION
홈서버 모니터링 스택의 Tempo로 trace를 보내도록 reporter 추가.
이미 micrometer-tracing-bridge-brave가 있고 logback의 prod profile이 traceId MDC를 JSON 로그에 박고 있으므로, Zipkin wire format reporter만 추가하면 Loki ↔ Tempo 양방향 점프 가능.

변경:
- build.gradle: io.zipkin.reporter2:zipkin-reporter-brave 추가 (Brave가 이미 classpath에 있어서 Spring Boot의 ZipkinAutoConfiguration이 ZipkinSpanHandler bean을 자동 생성)
- application-prod.yml:
  - management.tracing.propagation.type=b3,w3c — b3는 Brave 표준, w3c는 OTel 클라이언트와 호환
  - management.zipkin.tracing.endpoint=http://tempo:9411/api/v2/spans (ZIPKIN_ENDPOINT 환경변수로 오버라이드 가능)

샘플링 1.0은 가정 트래픽 기준. 운영 트래픽 증가 시 0.05~0.1 권장.

## Related issue 🛠

[//]: # (해당하는 이슈 번호 달아주기)

어떤 변경사항이 있었나요?

- [ ] 🐛 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, Swagger, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related

## Work Description ✏️

[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.

- 작업 내용

## Uncompleted Tasks 😅

[//]: # (없다면 N/A)

- [ ] Task1

## To Reviewers 📢

[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.
